### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ php:
   - 5.5
   - 5.4
 
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
-
 before_script:
   - composer install --dev --no-interaction
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 5.6
+  - 5.5
+  - 5.4
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+
+before_script:
+  - composer install --dev --no-interaction
+
+script:
+  - php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 | ^5.5 | ^6.5"

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
             "email": "joris@statik.be"
         }
     ],
+    "require": {
+        "php": ">=5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 | ^5.5 | ^6.5"
+    },
     "autoload": {
         "psr-0": {
             "ride\\library\\http\\jsonapi": ["src/"]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="Dependency Test Suite">
+            <directory>test/src/ride/library/http/jsonapi</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/test/src/ride/library/http/jsonapi/AbstractJsonApiElementTest.php
+++ b/test/src/ride/library/http/jsonapi/AbstractJsonApiElementTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\http\jsonapi;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractJsonApiElementTest extends PHPUnit_Framework_TestCase {
+abstract class AbstractJsonApiElementTest extends TestCase {
 
     abstract protected function createTestInstance();
 

--- a/test/src/ride/library/http/jsonapi/JsonApiDocumentTest.php
+++ b/test/src/ride/library/http/jsonapi/JsonApiDocumentTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\http\jsonapi;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class JsonApiDocumentTest extends PHPUnit_Framework_TestCase {
+class JsonApiDocumentTest extends TestCase {
 
     public function setUp() {
         $this->document = new JsonApiDocument();
@@ -31,6 +31,13 @@ class JsonApiDocumentTest extends PHPUnit_Framework_TestCase {
         $this->document->setQuery($query);
 
         $this->assertEquals($this->document->getQuery(), $query);
+    }
+
+    /**
+     * @expectedException ride\library\http\jsonapi\exception\JsonApiException
+     */
+    public function testSetStatusCodeShouldThrowJsonApiException() {
+        $this->document->setStatusCode(6000);
     }
 
     public function testStatusCode() {

--- a/test/src/ride/library/http/jsonapi/JsonApiErrorTest.php
+++ b/test/src/ride/library/http/jsonapi/JsonApiErrorTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\http\jsonapi;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class JsonApiErrorTest extends PHPUnit_Framework_TestCase {
+class JsonApiErrorTest extends TestCase {
 
     public function setUp() {
         $this->error = new JsonApiError();

--- a/test/src/ride/library/http/jsonapi/JsonApiQueryTest.php
+++ b/test/src/ride/library/http/jsonapi/JsonApiQueryTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\http\jsonapi;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class JsonApiQueryTest extends PHPUnit_Framework_TestCase {
+class JsonApiQueryTest extends TestCase {
 
     /**
      * @dataProvider providerGetInclude

--- a/test/src/ride/library/http/jsonapi/JsonApiTest.php
+++ b/test/src/ride/library/http/jsonapi/JsonApiTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\http\jsonapi;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class JsonApiTest extends PHPUnit_Framework_TestCase {
+class JsonApiTest extends TestCase {
 
     public function setUp() {
         $this->api = new JsonApi();


### PR DESCRIPTION
# Changed log

- add more tests.
- integrate the Travis build. See the Travis build [log](https://travis-ci.org/peter279k/ride-lib-http-jsonapi/builds/360774209).
- add the ```ext-json``` to check whether the json extension is installed.
- According to the [doc](http://php.net/manual/en/class.jsonserializable.php), it will support this at least ```php-5.4```.